### PR TITLE
docs: add working project links to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # ChronalLabs – Civic Technology Initiative (GSoC 2026)
 
+🌐 **Website:** [https://chronallab-site.vercel.app/](https://chronallab-site.vercel.app/)
+
 ## Overview
 
 ChronalLabs is an open-source civic-technology initiative focused on building practical, scalable tools that solve real-world public challenges.
@@ -58,7 +60,7 @@ Each project is scoped to be achievable within the GSoC timeline while remaining
 
 # Project Portfolio
 
-Below are the major project tracks under ChronalLabs.
+Below are the major project tracks under ChronalLabs. For a live overview, visit the [ChronalLabs website](https://chronallab-site.vercel.app/).
 
 ---
 


### PR DESCRIPTION
## Summary

Adds the working ChronalLabs website link to the README, as requested in issue #54.

### Changes
- Added website link (`https://chronallab-site.vercel.app/`) prominently at the top of README
- Added website reference in the Project Portfolio section

Closes #54

---
*This PR was created as part of a good first issue contribution.*