### PR TITLE
docs(expense-tracker): fix README entrypoint from main.py to app.py

### DIFF
--- a/Expense Tracker/readme.md
+++ b/Expense Tracker/readme.md
@@ -29,7 +29,7 @@ A sleek, lightweight **Personal Finance Dashboard** built with Python and Flask.
 
 ```text
 .
-├── main.py              # Application entry point & route handlers
+├── app.py               # Application entry point & route handlers
 ├── models.py            # Database schema (User, Expense, Budget)
 ├── static/              # CSS, JavaScript, and Images
 ├── templates/           # HTML Jinja2 templates
@@ -59,11 +59,11 @@ pip install flask flask-sqlalchemy flask-login
 Run the application
 
 Bash
-python main.py
+python app.py
 The app will initialize the database and start at http://127.0.0.1:5000/.
 
 🔐 Security Note
-For production environments, ensure you change the SECRET_KEY in main.py:
+For production environments, ensure you change the SECRET_KEY in app.py:
 
 Python
 app.config['SECRET_KEY'] = 'your-secure-random-string-here'


### PR DESCRIPTION
## Summary

Fix the Expense Tracker README so the documented run command matches the file that actually exists on disk. README says `python main.py`, but the entry point is `app.py`.

## Why

Users following the quickstart hit `ModuleNotFoundError: No module named 'main'` because no `main.py` exists in the sub-project -- the Flask app lives in `Expense Tracker/app.py` and imports `db` from `models.py`. The incorrect filename appears in three places in the README (project tree, run command, and the security note referencing `SECRET_KEY`). This PR updates all three.

## Changes

Only `Expense Tracker/readme.md` is touched. Three string replacements:

- File tree: `├── main.py  # Application entry point` → `├── app.py  # Application entry point`
- Run command: `python main.py` → `python app.py`
- Security note: `change the SECRET_KEY in main.py` → `change the SECRET_KEY in app.py`

## Testing

- Verified `Expense Tracker/app.py` exists and is importable as the Flask entry point (`grep -n "app.run\|if __name__" "Expense Tracker/app.py"`).
- Verified no other `main.py` reference remains in `Expense Tracker/readme.md`.
- Diff is docs-only; no code path changed.

Fixes #71

This contribution was developed with AI assistance (Claude Code).
